### PR TITLE
Update LinSerial.c for gcc

### DIFF
--- a/ARDOPCommonCode/LinSerial.c
+++ b/ARDOPCommonCode/LinSerial.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
 
 //#include "ARDOPC.h"
 


### PR DESCRIPTION
/ardop/ARDOPCommonCode/LinSerial.c:22:1: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
   21 | #include <unistd.h>
  +++ |+#include <string.h>
   22 |