### PR TITLE
Add RXO ProtocolMode (ardopc) 

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -624,13 +624,6 @@ char * strlop(char * buf, char delim)
 	return ptr;
 }
 
-#ifdef WIN32
-float round(float x)
-{
-	return floorf(x + 0.5f);
-}
-#endif
-
 void GetSemaphore()
 {
 }

--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -111,7 +111,7 @@ BOOL Use600Modes = FALSE;
 BOOL FSKOnly = FALSE;
 BOOL fastStart = TRUE;
 BOOL ConsoleLogLevel = LOGDEBUG;
-BOOL FileLogLevel = LOGDEBUG;
+BOOL FileLogLevel = LOGDEBUGPLUS;
 BOOL EnablePingAck = TRUE;
 
 BOOL gotGPIO = FALSE;

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -37,7 +37,6 @@ extern const char ProductVersion[];
 #endif
 
 #ifdef WIN32
-float round(float x);
 typedef void *HANDLE;
 #else
 #define HANDLE int

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -11,7 +11,7 @@ extern const char ProductVersion[];
 //	Sound interface buffer size
 
 #define SendSize 1200		// 100 mS for now
-#define ReceiveSize 512	// Must be 1024 for FFT (or we will need torepack frames)
+// #define ReceiveSize 512	// Must be 1024 for FFT (or we will need torepack frames)
 #define NumberofinBuffers 4
 
 // Host to TNC Buffer Size
@@ -377,7 +377,8 @@ enum _ProtocolMode
 {
 	Undef,
 	FEC,
-	ARQ
+	ARQ,
+	RXO  // Receive Only.  Decode all possible frames while recovering SessionID.  ProtocolState should always be DISC
 };
 
 extern enum _ProtocolMode ProtocolMode;

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -61,6 +61,7 @@ extern unsigned int pttOnTime;
 #define LOGNOTICE 5
 #define LOGINFO 6
 #define LOGDEBUG 7
+#define LOGDEBUGPLUS 8
 
 #include <time.h>
 

--- a/ARDOPC/HostInterface.c
+++ b/ARDOPC/HostInterface.c
@@ -220,7 +220,10 @@ void ProcessCommandFromHost(char * strCMD)
 						SendReplyToHost(cmdCopy);
 						goto cmddone;
 					}
-					sprintf(strFault, "Not from mode FEC");
+					if (ProtocolMode == RXO)
+						sprintf(strFault, "Not from mode RXO");
+					else
+						sprintf(strFault, "Not from mode FEC");
 					goto cmddone;
 				}
 			}
@@ -1106,6 +1109,9 @@ void ProcessCommandFromHost(char * strCMD)
 			if (ProtocolMode == ARQ)
 				sprintf(cmdReply, "PROTOCOLMODE ARQ");
 			else
+			if (ProtocolMode == RXO)
+				sprintf(cmdReply, "PROTOCOLMODE RXO");
+			else
 				sprintf(cmdReply, "PROTOCOLMODE FEC");
 
 			SendReplyToHost(cmdReply);
@@ -1115,6 +1121,9 @@ void ProcessCommandFromHost(char * strCMD)
 		if (strcmp(ptrParams, "ARQ") == 0)
 			ProtocolMode = ARQ;
 		else 
+		if (strcmp(ptrParams, "RXO") == 0)
+			ProtocolMode = RXO;
+		else
 		if (strcmp(ptrParams, "FEC") == 0)
 			ProtocolMode = FEC;
 		else
@@ -1124,6 +1133,9 @@ void ProcessCommandFromHost(char * strCMD)
 		}
 		if (ProtocolMode == ARQ)
 			sprintf(cmdReply, "PROTOCOLMODE now ARQ");
+		else
+		if (ProtocolMode == RXO)
+			sprintf(cmdReply, "PROTOCOLMODE now RXO");
 		else
 			sprintf(cmdReply, "PROTOCOLMODE now FEC");
 

--- a/ARDOPC/Makefile
+++ b/ARDOPC/Makefile
@@ -2,7 +2,7 @@
 
 OBJS = ARDOPCommon.o LinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o i2cDisplay.o ALSASound.o \
 ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
-berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o wav.o
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o wav.o RXO.o
 
 # Configuration:
 CFLAGS = -DLINBPQ -MMD -g 

--- a/ARDOPC/Makefile
+++ b/ARDOPC/Makefile
@@ -2,7 +2,7 @@
 
 OBJS = ARDOPCommon.o LinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o i2cDisplay.o ALSASound.o \
 ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
-berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o wav.o
 
 # Configuration:
 CFLAGS = -DLINBPQ -MMD -g 

--- a/ARDOPC/Makefile_mingw32
+++ b/ARDOPC/Makefile_mingw32
@@ -2,7 +2,7 @@
 
 OBJS = ARDOPCommon.o WinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o Waveout.o \
 ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
-berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o hid.o wav.o
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o hid.o wav.o RXO.o
 
 # Configuration:
 CFLAGS = -DLINBPQ -MMD -g 

--- a/ARDOPC/Makefile_mingw32
+++ b/ARDOPC/Makefile_mingw32
@@ -1,0 +1,25 @@
+#	ARDOPC Makefile for mingw32-make.exe from winlibs Intel/AMD 32-bit 
+
+OBJS = ARDOPCommon.o WinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o Waveout.o \
+ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o hid.o wav.o
+
+# Configuration:
+CFLAGS = -DLINBPQ -MMD -g 
+CC = gcc
+
+vpath %.c ../ARDOPCommonCode
+vpath %.h ../ARDOPCommonCode
+vpath %.o ./
+			                       
+all: ardopc
+			
+ardopc: $(OBJS)
+	gcc $(OBJS) -Xlinker -Map=output.map -lm -lpthread -lwsock32 -lwinmm -lsetupapi -o ardopc
+
+
+-include *.d
+
+clean :
+	del ardopc $(OBJS)
+

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -14,6 +14,7 @@ FILE * fp1;
 // Function to generate the Two-tone leader and Frame Sync (used in all frame types) 
 
 extern short Dummy;
+extern int DriveLevel;
 
 int intSoftClipCnt = 0;
 
@@ -1158,6 +1159,8 @@ void SampleSink(short Sample)
 	int intFilLen = intN / 2;
 	int j;
 	float intFilteredSample = 0;			//  Filtered sample
+
+	Sample = Sample * DriveLevel / 100;
 
 	//	We save the previous intN samples
 	//	The samples are held in a cyclic buffer

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -228,6 +228,8 @@ Reenter:
 			intDataPtr += 1;
 		}
 		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		if (intDataBytesPerCar == 0)
+			sprintf(DebugMess + strlen(DebugMess), "(None)");
 		WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 
 		if (Type == PktFrameHeader)

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -1,5 +1,11 @@
 //	Sample Creation routines (encode and filter) for ARDOP Modem
 
+#ifdef WIN32
+#define _CRT_SECURE_NO_DEPRECATE
+#define _USE_32BIT_TIME_T
+#include <windows.h>
+#endif
+
 #include "ARDOPC.h"
 
 

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -55,6 +55,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 	UCHAR bytMask;
 	UCHAR bytSymToSend;
 	short intSample;
+	char DebugMess[256];
 	if (intLeaderLen == 0)
 		intLeaderLenMS = LeaderLength;
 	else
@@ -69,6 +70,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 
 	// note revised To accomodate 1 parity symbol per byte (10 symbols total)
 
+	sprintf(DebugMess, "LeaderAndSYNC tones : ");
 	for(j = 0; j < 2; j++)		 // for the 2 bytes of the frame type
 	{              
 		bytMask = 0xc0;
@@ -79,6 +81,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 				bytSymToSend = (bytMask & bytEncodedBytes[j]) >> (2 * (3 - k));
 			else
 				bytSymToSend = ComputeTypeParity(bytEncodedBytes[0]);
+			sprintf(DebugMess + strlen(DebugMess), "%d", bytSymToSend);
 
 			for(n = 0; n < 240; n++)
 			{
@@ -92,6 +95,8 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 			bytMask = bytMask >> 2;
 		}
 	}
+	// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 }
 
 
@@ -109,6 +114,7 @@ void Mod4FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int 
 
     char strType[18] = "";
     char strMod[16] = "";
+    char DebugMess[1024];
 
 	UCHAR bytSymToSend, bytMask, bytMinQualThresh;
 
@@ -185,13 +191,15 @@ Reenter:
 		
 		dblCarScalingFactor = 1.0; //  (scaling factors determined emperically to minimize crest factor) 
 
+		sprintf(DebugMess, "Mod4FSKDataAndPlay 1Car tones :");
 		for (m = 0; m < intDataBytesPerCar; m++)  // For each byte of input data
 		{
 			bytMask = 0xC0;		 // Initialize mask each new data byte
-			
+			sprintf(DebugMess + strlen(DebugMess), " ");
 			for (k = 0; k < 4; k++)		// for 4 symbol values per byte of data
 			{
 				bytSymToSend = (bytMask & bytEncodedBytes[intDataPtr]) >> (2 * (3 - k)); // Values 0-3
+				sprintf(DebugMess + strlen(DebugMess), "%d", bytSymToSend);
 
 				for (n = 0; n < intSampPerSym; n++)	 // Sum for all the samples of a symbols 
 				{
@@ -219,6 +227,8 @@ Reenter:
 			}
 			intDataPtr += 1;
 		}
+		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 
 		if (Type == PktFrameHeader)
 		{

--- a/ARDOPC/RXO.c
+++ b/ARDOPC/RXO.c
@@ -1,0 +1,283 @@
+#include "ARDOPC.h"
+#include "../ARDOPCommonCode/ardopcommon.h"
+#include "RXO.h"
+
+extern UCHAR bytSessionID;
+extern UCHAR bytFrameData1[760];
+
+// Function to compute the "distance" from a specific bytFrame Xored by bytID using 1 symbol parity 
+// The tones representing the Frame Type include two parity symbols which should be identical, and
+// should match ComputeTypeParity(bytFrameType).  For RXO mode, the SessionID is unknown/unreliable,
+// So Tones 5-8, which represent FrameType ^ SessionID are not used to compute FrameType.  However,
+// the second copy of the parity symbol (Tone 9) should be used.  RxoComputeDecodeDistance() differs
+// from ComputeDecodeDistance() in its use of the second copy of the parity symbol.
+// (It also differs from ComputeDecodeDistance() by not requiring intTonePtr or bytId arguments.)
+float RxoComputeDecodeDistance(int * intToneMags, UCHAR bytFrameType)
+{
+	float dblDistance = 0;
+	int int4ToneSum;
+	int intToneIndex;
+	UCHAR bytMask = 0xC0;
+	int j, k;
+
+	for (j = 0; j < 10; j++)
+	{
+		if (j > 4 && j != 9)  // ignore symbols 5-8, which are useless if SessionID is unknown/unreliable
+			continue;
+			
+		int4ToneSum = 0;
+		for (k = 0; k < 4; k++)
+		{
+			int4ToneSum += intToneMags[(4 * j) + k];
+		}
+		if (int4ToneSum == 0)
+			int4ToneSum = 1;		//  protects against possible overflow
+		if (j < 4)
+		    intToneIndex = (bytFrameType & bytMask) >> (6 - 2 * j);
+		else
+			intToneIndex = ComputeTypeParity(bytFrameType);
+
+		dblDistance += 1.0f - ((1.0f * intToneMags[(4 * j) + intToneIndex]) / (1.0f * int4ToneSum));
+		bytMask = bytMask >> 2;
+	}
+	
+	dblDistance = dblDistance / 6;		// normalize back to 0 to 1 range 
+	return dblDistance;
+}
+
+// Decode the likely SessionID. If the decode distance is less than dblMaxDistance, then 
+// set bytSessionID and return TRUE, else leave bytSessionID unchanged and return FALSE.
+// SessionID is useful in RXO mode to indicate whether decoded frames are part of the
+// same session (or at least another session between the same two stations).
+BOOL RxoDecodeSessionID(UCHAR bytFrameType, int * intToneMags, float dblMaxDistance)
+{
+	UCHAR bytID = 0;
+	int int4ToneSum;
+	int intMaxToneMag;
+	UCHAR bytTone;
+	int j, k;
+	float dblDistance = 1.0;
+
+	// Direct decoding of the tones 5-8
+	for (j = 20; j < 36; j += 4)
+	{
+		int4ToneSum = 0;
+		for (k = 0; k < 4; k++)
+			int4ToneSum += intToneMags[j + k];
+
+		intMaxToneMag = 0;
+		for (k = 0; k < 4; k++)
+		{
+			if (intToneMags[j + k] > intMaxToneMag)
+			{
+				bytTone = k;
+				intMaxToneMag = intToneMags[j + k];
+			}
+		}
+		bytID = (bytID << 2) + bytTone;
+		dblDistance -= 0.25 * intMaxToneMag / int4ToneSum;
+	}
+	bytID ^= bytFrameType;
+	
+	if (dblDistance > dblMaxDistance)
+	{
+		if (bytID == bytSessionID)
+			WriteDebugLog(LOGDEBUG, "[RXO DecodeSessionID FAIL] Decoded ID=H%02X Dist=%.2f (%.2f Max). (Matches Prior ID)", 
+					bytID, dblDistance, dblMaxDistance, bytSessionID);	
+		else
+			WriteDebugLog(LOGDEBUG, "[RXO DecodeSessionID FAIL] Decoded ID=H%02X Dist=%.2f (%.2f Max). (Retain prior ID=H%02X)", 
+					bytID, dblDistance, dblMaxDistance, bytSessionID);	
+		return FALSE;
+	}
+	if (bytID == bytSessionID)
+	{
+		WriteDebugLog(LOGDEBUG, "[RXO DecodeSessionID OK  ] Decoded ID=H%02X Dist=%.2f (%.2f Max). (No change)", 
+				bytID, dblDistance, dblMaxDistance, bytSessionID);		
+	return TRUE;
+	}
+	WriteDebugLog(LOGDEBUG, "[RXO DecodeSessionID OK  ] Decoded ID=H%02X Dist=%.2f (%.2f Max). (Prior ID=H%02X)", 
+			bytID, dblDistance, dblMaxDistance, bytSessionID);	
+	bytSessionID = bytID;
+	return TRUE;
+}
+
+int RxoMinimalDistanceFrameType(int * intToneMags)
+{
+	float dblMinDistance = 5; // minimal distance. initialize to large value
+	UCHAR bytIatMinDistance;
+	float dblDistance;
+	int i;
+
+	// Search through all the valid frame types finding the minimal distance 
+	for (i = 0; i < bytValidFrameTypesLengthALL; i++)
+	{
+		dblDistance = RxoComputeDecodeDistance(intToneMags, bytValidFrameTypesALL[i]);
+		if (dblDistance < dblMinDistance)
+		{
+			dblMinDistance = dblDistance;
+			bytIatMinDistance = bytValidFrameTypesALL[i];
+		}
+	}
+
+	WriteDebugLog(LOGDEBUG, "RXO MD Decode Type=H%02X:%s, Dist = %.2f", bytIatMinDistance, Name(bytIatMinDistance), dblMinDistance);
+	if (dblMinDistance < 0.3)
+	{
+		// Decode of Frame Type is Good independent of bytSessionID
+		WriteDebugLog(LOGDEBUG, "[Frame Type Decode OK  ] H%02X:%s", bytIatMinDistance, Name(bytIatMinDistance));
+
+		// Only update bytSessionID if the decode distance is nearly as good as the 
+		// decode distance for the Frame Type.  Recall that the two parity tones and 
+		// the sparseness of ValidFrameTypesALL increase the computed dblMinDistance 
+		// for an invalid or noisy FrameType, while the decode distance for the 
+		// SessionID is based only on the noise in the four tones since the parity
+		// tones are not useful for this, and RxoDecodeSessionID() considers all
+		// SessionID values to be equally likely (no sparseness).  Also, failure to
+		// accept a decoded SessionID does not impact the decoding of the remainder
+		// of the frame.  In RXO mode, SessionID is only used as an indicator that 
+		// decoded frames are part of the same session, or at lease a session between
+		// the same stations.
+		RxoDecodeSessionID(bytIatMinDistance, intToneMags, dblMinDistance + 0.02);
+		
+		return bytIatMinDistance;
+	}
+	// Failure (independent of SessionID)
+	WriteDebugLog(LOGDEBUG, "[Frame Type Decode Fail]");
+	return -1;		// indicates poor quality decode so don't use
+}
+
+void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL blnFrameDecodedOK)
+{
+	char strMsg[4096];
+	int intMsgLen;
+	UCHAR * notUtf8;
+
+	if (blnFrameDecodedOK)
+	{
+		if (bytFrameType >= 0x31 && bytFrameType <= 0x38)
+		{
+			// Is there a reason why frameLen is not defined for ConReq?
+			WriteDebugLog(LOGDEBUG, "    [RXO %02X] ConReq data is callerID targetID", bytSessionID);
+			frameLen = strlen((char*) bytData);
+		}
+		else if (bytFrameType >= 0x39 && bytFrameType <= 0x3C)
+		{
+			WriteDebugLog(LOGDEBUG, "    [RXO %02X] ConAck data is the length (in tens of ms) of the received leader repeated 3 times: %d %d %d",
+				bytSessionID, bytFrameData1[0], bytFrameData1[1], bytFrameData1[2]);
+		}
+		else if (bytFrameType >= 0xE0)
+		{
+			WriteDebugLog(LOGDEBUG, "    [RXO %02X] DataAck FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
+		}
+		else if (bytFrameType <= 0x1F)
+		{
+			WriteDebugLog(LOGDEBUG, "    [RXO %02X] DataNak FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
+		}
+
+		WriteDebugLog(LOGDEBUG, "    [RXO %02X] %s frame received OK.  frameLen = %d", 
+				bytSessionID, Name(bytFrameType), frameLen);
+		bytData[frameLen] = 0;
+		if (frameLen > 0)
+		{
+			sprintf(strMsg, "    [RXO %02X] %d bytes of data as hex values:\n", bytSessionID, frameLen);
+			intMsgLen = strlen(strMsg);
+			for (int i = 0; i < frameLen; i++)
+			{
+				sprintf(strMsg + intMsgLen, "%02X ", bytData[i]);
+				intMsgLen += 3;
+			}
+			WriteDebugLog(LOGDEBUG, "%s", strMsg);
+			notUtf8 = utf8_check(bytData);
+			if (notUtf8 == NULL)
+			{
+				for (int i = 0; i < frameLen; i++)
+				{
+					if (bytData[i] == 0x0D && bytData[i + 1] != 0x0A)
+						bytData[i] = 0x0A;
+				}
+				WriteDebugLog(LOGDEBUG, "    [RXO %02X] %d bytes of data as UTF-8 text:\n%s", bytSessionID, frameLen, bytData);
+			}
+			else
+				WriteDebugLog(LOGDEBUG, "    [RXO %02X] Data does not appear to be valid UTF-8 text.", bytSessionID);			
+		}
+		sprintf(strMsg, "STATUS [RXO %02X] %s frame received OK.", bytSessionID, Name(bytFrameType));
+		SendCommandToHost(strMsg);
+	}
+	else
+	{
+		WriteDebugLog(LOGDEBUG, "    [RXO %02X] %s frame decode FAIL.", 
+				bytSessionID, Name(bytFrameType), frameLen);
+		sprintf(strMsg, "STATUS [RXO %02X] %s frame decode FAIL.", bytSessionID, Name(bytFrameType));
+		SendCommandToHost(strMsg);
+		bytData[frameLen] = 0;
+		
+	}
+	
+}
+
+
+/*
+ * The utf8_check() function scans the '\0'-terminated string starting
+ * at s. It returns a pointer to the first byte of the first malformed
+ * or overlong UTF-8 sequence found, or NULL if the string contains
+ * only correct UTF-8. It also spots UTF-8 sequences that could cause
+ * trouble if converted to UTF-16, namely surrogate characters
+ * (U+D800..U+DFFF) and non-Unicode positions (U+FFFE..U+FFFF). This
+ * routine is very likely to find a malformed sequence if the input
+ * uses any other encoding than UTF-8. It therefore can be used as a
+ * very effective heuristic for distinguishing between UTF-8 and other
+ * encodings.
+ *
+ * I wrote this code mainly as a specification of functionality; there
+ * are no doubt performance optimizations possible for certain CPUs.
+ *
+ * Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/> -- 2005-03-30
+ * License: http://www.cl.cam.ac.uk/~mgk25/short-license.html
+ *
+ * The above license URL indicates that the following code is licensed
+ * by Markus Kuhn under the users choice of multiple licenses including
+ * Apache, BSD, GPL, LGPL, MIT, amd CC0.
+ */
+
+unsigned char *utf8_check(unsigned char *s)
+{
+  while (*s) {
+    if (*s < 0x80)
+      /* 0xxxxxxx */
+      s++;
+    else if ((s[0] & 0xe0) == 0xc0) {
+      /* 110XXXXx 10xxxxxx */
+      if ((s[1] & 0xc0) != 0x80 ||
+	  (s[0] & 0xfe) == 0xc0)                        /* overlong? */
+	return s;
+      else
+	s += 2;
+    } else if ((s[0] & 0xf0) == 0xe0) {
+      /* 1110XXXX 10Xxxxxx 10xxxxxx */
+      if ((s[1] & 0xc0) != 0x80 ||
+	  (s[2] & 0xc0) != 0x80 ||
+	  (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80) ||    /* overlong? */
+	  (s[0] == 0xed && (s[1] & 0xe0) == 0xa0) ||    /* surrogate? */
+	  (s[0] == 0xef && s[1] == 0xbf &&
+	   (s[2] & 0xfe) == 0xbe))                      /* U+FFFE or U+FFFF? */
+	return s;
+      else
+	s += 3;
+    } else if ((s[0] & 0xf8) == 0xf0) {
+      /* 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx */
+      if ((s[1] & 0xc0) != 0x80 ||
+	  (s[2] & 0xc0) != 0x80 ||
+	  (s[3] & 0xc0) != 0x80 ||
+	  (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80) ||    /* overlong? */
+	  (s[0] == 0xf4 && s[1] > 0x8f) || s[0] > 0xf4) /* > U+10FFFF? */
+	return s;
+      else
+	s += 4;
+    } else
+      return s;
+  }
+
+  return NULL;
+}
+

--- a/ARDOPC/RXO.h
+++ b/ARDOPC/RXO.h
@@ -1,0 +1,7 @@
+#include "ARDOPC.h"
+ 
+float RxoComputeDecodeDistance(int * intToneMags, UCHAR bytFrameType);
+BOOL RxoDecodeSessionID(UCHAR bytFrameType, int * intToneMags, float dblMaxDistance);
+int RxoMinimalDistanceFrameType(int * intToneMags);
+void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL blnFrameDecodedOK);
+unsigned char *utf8_check(unsigned char *s);

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -2088,6 +2088,8 @@ BOOL DemodFrameType4FSK(int intPtr, short * intSamples, int * intToneMags)
 {
 	float dblReal, dblImag;
 	int i;
+	int intMagSum;
+	UCHAR bytSym;
 
 	if ((intFilteredMixedSamplesLength - intPtr) < 2400)
 		return FALSE;
@@ -2105,8 +2107,22 @@ BOOL DemodFrameType4FSK(int intPtr, short * intSamples, int * intToneMags)
 		GoertzelRealImag(intSamples, intPtr, 240, 1425 / 50.0f, &dblReal, &dblImag);
 		intToneMags[3 + 4 * i] = (int)powf(dblReal, 2) + powf(dblImag, 2);
 		intPtr += 240;
+
+		// intMagSum and bytSym are used only to write tone values to debug log.
+		intMagSum = intToneMags[4 * i] + intToneMags[1 + 4 * i] + intToneMags[2 + 4 * i] + intToneMags[3 + 4 * i];
+		if (intToneMags[4 * i] > intToneMags[1 + 4 * i] && intToneMags[4 * i] > intToneMags[2 + 4 * i] && intToneMags[4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 0;
+		else if (intToneMags[1 + 4 * i] > intToneMags[4 * i] && intToneMags[1 + 4 * i] > intToneMags[2 + 4 * i] && intToneMags[1 + 4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 1;
+		else if (intToneMags[2 + 4 * i] > intToneMags[4 * i] && intToneMags[2 + 4 * i] > intToneMags[1 + 4 * i] && intToneMags[2 + 4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 2;
+		else
+			bytSym = 3;
+
+	    // Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		WriteDebugLog(LOGDEBUGPLUS, "FrameType_bytSym : %d(%d %03.0f/%03.0f/%03.0f/%03.0f)", bytSym, intMagSum, 100.0*intToneMags[4 * i]/intMagSum, 100.0*intToneMags[1 + 4 * i]/intMagSum, 100.0*intToneMags[2 + 4 * i]/intMagSum, 100.0*intToneMags[3 + 4 * i]/intMagSum);
 	}
-	
+
 	return TRUE;
 }
 

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -2550,6 +2550,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 	static UCHAR bytSymHistory[3];
 	int j;
 	UCHAR bytData = 0;
+	char DebugMess[1024];
 
 	int * intToneMagsptr = &intToneMags[Carrier][intToneMagsIndex[Carrier]];
 	   
@@ -2561,7 +2562,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 	dblSearchFreq = intCenterFreq + (1.5f * intBaud);	// the highest freq (equiv to lowest sent freq because of sideband reversal)
 
 	// Do one symbol
-
+	sprintf(DebugMess, "4FSK_bytSym :");
 	for (j = 0; j < 4; j++)		// for each 4FSK symbol (2 bits) in a byte
 	{
 		dblMagSum = 0;
@@ -2590,6 +2591,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 		else
 			bytSym = 3;
 
+		sprintf(DebugMess + strlen(DebugMess), " %d(%.0f %03.0f/%03.0f/%03.0f/%03.0f)", bytSym, dblMagSum, 100*dblMag[0]/dblMagSum, 100*dblMag[1]/dblMagSum, 100*dblMag[2]/dblMagSum, 100*dblMag[3]/dblMagSum);
 		bytData = (bytData << 2) + bytSym;
 
 		// !!!!!!! this needs attention !!!!!!!!
@@ -2612,6 +2614,8 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 		Start += intSampPerSym; // advance the pointer one symbol
 	}
 
+    // Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 	if (AccumulateStats)
 		intFSKSymbolCnt += 4;
  

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -1,5 +1,11 @@
 //	ARDOP Modem Decode Sound Samples
 
+#ifdef WIN32
+#define _CRT_SECURE_NO_DEPRECATE
+#define _USE_32BIT_TIME_T
+#include <windows.h>
+#endif
+
 #include "ARDOPC.h"
 
 #pragma warning(disable : 4244)		// Code does lots of float to int
@@ -27,9 +33,6 @@
 #define PKTLED LED3		// flash when packet received
 extern unsigned int PKTLEDTimer;
 #endif
-
-//#define max(x, y) ((x) > (y) ? (x) : (y))
-//#define min(x, y) ((x) < (y) ? (x) : (y))
 
 void SendFrametoHost(unsigned char *data, unsigned dlen);
 

--- a/ARDOPC/WinSerial.c
+++ b/ARDOPC/WinSerial.c
@@ -30,7 +30,7 @@ extern BOOL UseKISS;			// Enable Packet (KISS) interface
 int Speed;
 int PollDelay;
 
-SOCKET PktSock;
+extern SOCKET PktSock;
 extern SOCKET PktListenSock;
 
 extern BOOL PKTCONNECTED;
@@ -130,8 +130,6 @@ extern volatile int RXBPtr;
 #define DebugWaitCompletion 4
 #define DebugReadCompletion 8
 */
-
-HANDLE hControl;
 
 typedef struct _SERIAL_STATUS {
     unsigned long Errors;

--- a/ARDOPC/WinSerial.c
+++ b/ARDOPC/WinSerial.c
@@ -19,7 +19,7 @@
 #include "ARDOPC.h"
 
 VOID ProcessSCSPacket(UCHAR * rxbuffer, int Length);
-WriteCOMBlock(hDevice, Message, MsgLen);
+BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 int ReadCOMBlock(HANDLE fd, char * Block, int MaxLength);
 VOID ProcessKISSBytes(UCHAR * RXBuffer, int Read);
 void KISSTCPPoll();
@@ -217,7 +217,7 @@ int BPQSerialGetData(UCHAR * Message, unsigned int BufLen, unsigned long * MsgLe
 {
 	DWORD dwLength = 0;
 	DWORD Available = 0;
-	int Length, RealLen = 0;
+	long unsigned int Length, RealLen = 0;
 	
 	int ret = PeekNamedPipe(hDevice, NULL, 0, NULL, &Available, NULL);
 
@@ -296,7 +296,7 @@ BOOL SerialHostInit()
 {
 	WSADATA WsaData;			 // receives data from WSAStartup
 	unsigned long OpenCount = 0;
-	unsigned int Errorval;
+	long unsigned int Errorval;
 	char * Baud = strlop(PORTNAME, ',');
 
 	VCOM = TRUE;

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -225,7 +225,8 @@ VOID WriteDebugLog(int Level, const char * format, ...)
 	if (!DebugLog)
 		return;
 
-	WriteLog(Mess, DEBUGLOG);
+	if (Level <= FileLogLevel)
+		WriteLog(Mess, DEBUGLOG);
 	return;
 }
 

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -1112,21 +1112,7 @@ int OpenSoundCapture(char * CaptureDevice, int m_sampleRate, char * ErrorMsg)
 		return FALSE;
 	}
 
-//	Debugprintf("Capture using %d channels", m_recchannels);
-
-	int i;
-	short buf[256];
-
-	for (i = 0; i < 10; ++i)
-	{
-		if ((err = snd_pcm_readi (rechandle, buf, 128)) != 128)
-		{
-			Debugprintf("read from audio interface failed (%s)",
-				 snd_strerror (err));
-		}
-	}
-
-//	Debugprintf("Read got %d", err);
+	snd_pcm_start(rechandle);  // without this avail stuck at 0
 
  	return TRUE;
 }
@@ -1649,7 +1635,7 @@ void SoundFlush()
 	// samples sent is is in SampleNo, time started in mS is in pttOnTime.
 	// calculate time to stop
 
-	txlenMs = SampleNo / 12 + 200;		// 12000 samples per sec. 20 mS TXTAIL
+	txlenMs = SampleNo / 12 + 20;		// 12000 samples per sec. 20 mS TXTAIL
 
 	Debugprintf("Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
 
@@ -1691,8 +1677,6 @@ void SoundFlush()
 	}
 */
 
-	OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);	
-
 	// I think we should turn round the link here. I dont see the point in
 	// waiting for MainPoll
 
@@ -1710,6 +1694,7 @@ void SoundFlush()
 
 	KeyPTT(FALSE);		 // Unkey the Transmitter
 
+	OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);
 	StartCapture();
 	return;
 }

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -49,6 +49,7 @@ void displayLevel(int max);
 BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 VOID processargs(int argc, char * argv[]);
 void Send5SecTwoTone();
+void setProtocolMode(char* strMode);
 
 int initdisplay();
 
@@ -69,6 +70,7 @@ BOOL UseRightRX = TRUE;
 BOOL UseLeftTX = TRUE;
 BOOL UseRightTX = TRUE;
 
+extern BOOL InitRXO;
 extern BOOL WriteRxWav;
 extern BOOL TwoToneAndExit;
 

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -48,6 +48,7 @@ int PackSamplesAndSend(short * input, int nSamples);
 void displayLevel(int max);
 BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 VOID processargs(int argc, char * argv[]);
+void Send5SecTwoTone();
 
 int initdisplay();
 
@@ -69,6 +70,7 @@ BOOL UseLeftTX = TRUE;
 BOOL UseRightTX = TRUE;
 
 extern BOOL WriteRxWav;
+extern BOOL TwoToneAndExit;
 
 char LogDir[256] = "";
 
@@ -593,6 +595,14 @@ void main(int argc, char * argv[])
 
 	if (sigaction(SIGPIPE, &act, NULL) < 0) 
 		perror ("SIGPIPE");
+
+	if (TwoToneAndExit)
+	{
+		InitSound();
+		WriteDebugLog(LOGINFO, "Sending a 5 second 2-tone signal. Then exiting ardop.");
+		Send5SecTwoTone();
+		return;
+	}
 
 	ardopmain();
 

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -518,7 +518,7 @@ int rawhid_recv(int num, void *buf, int len, int timeout)
 	unsigned char tmpbuf[516];
 	OVERLAPPED ov;
 	DWORD r;
-	int n;
+	long unsigned int n;
 
 	if (sizeof(tmpbuf) < len + 1) return -1;
 	hid = get_hid(num);
@@ -928,7 +928,7 @@ void DecodeCM108(char * ptr)
 	char product[256];
 
 	struct hid_device_info *devs, *cur_dev;
-	const char *path_to_open = NULL;
+	char *path_to_open = NULL;
 	hid_device *handle = NULL;
 
 	if (strlen(ptr) > 16)

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -77,6 +77,7 @@ extern char PlaybackDevice[80];
 int extraDelay = 0;				// Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
+BOOL InitRXO = FALSE;
 BOOL WriteRxWav = FALSE;
 BOOL TwoToneAndExit = FALSE;
 
@@ -157,6 +158,7 @@ static struct option long_options[] =
 	{"extradelay",  required_argument, 0 , 'e'},
 	{"leaderlength",  required_argument, 0 , 'x'},
 	{"trailerlength",  required_argument, 0 , 't'},
+	{"receive", no_argument, 0, 'r'},
 	{"writewav",  no_argument, 0, 'w'},
 	{"twotone", no_argument, 0, 'n'},
 	{"help",  no_argument, 0 , 'h'},
@@ -192,6 +194,7 @@ char HelpScreen[] =
 	"-e val or --extradelay val        Extend no response timeot for use on paths with long delay\n"
 	"--leaderlength val                Sets Leader Length (mS)\n"
 	"--trailerlength val               Sets Trailer Length (mS)\n"
+	"-r or --receiveonly               Start in RXO (receive only) mode.\n"
 	"-w or --writewav                  Write WAV files of received audio for debugging.\n"
 	"-n or --twotone                   Send a 5 second two tone signal and exit.\n"
 	"\n"
@@ -210,7 +213,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzwn", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytrzwn", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -335,6 +338,10 @@ void processargs(int argc, char * argv[])
 
 		case 't':
 			TrailerLength = atoi(optarg);
+			break;
+
+		case 'r':
+			InitRXO = TRUE;
 			break;
 
 		case 'w':

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -2,7 +2,7 @@
 //	Code Common to all versions of ARDOP. 
 //
 
-const char ProductVersion[] = "2.0.3.2";
+const char ProductVersion[] = "2.0.3.2-pflarue-3";
 
 //	2.0.3.1 November 2023
 
@@ -14,6 +14,12 @@ const char ProductVersion[] = "2.0.3.2";
 //	Add Craig KM6LYW's snd_pcm_hw_params_set_period_size_near patch
 //	Set default TrailerLength to 20 (ms)
 //	Add --trailerlength command line parameter
+
+// 2.0.3.2-pflarue-3  December 2023
+
+// Modify SoundFlush() and OpenSoundCapture() to reduce delay decoding
+// received audio after transmitting.
+
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -78,6 +78,7 @@ int extraDelay = 0;				// Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
 BOOL WriteRxWav = FALSE;
+BOOL TwoToneAndExit = FALSE;
 
 int PTTMode = PTTRTS;				// PTT Control Flags.
 
@@ -157,6 +158,7 @@ static struct option long_options[] =
 	{"leaderlength",  required_argument, 0 , 'x'},
 	{"trailerlength",  required_argument, 0 , 't'},
 	{"writewav",  no_argument, 0, 'w'},
+	{"twotone", no_argument, 0, 'n'},
 	{"help",  no_argument, 0 , 'h'},
 	{ NULL , no_argument , NULL , no_argument }
 };
@@ -191,6 +193,7 @@ char HelpScreen[] =
 	"--leaderlength val                Sets Leader Length (mS)\n"
 	"--trailerlength val               Sets Trailer Length (mS)\n"
 	"-w or --writewav                  Write WAV files of received audio for debugging.\n"
+	"-n or --twotone                   Send a 5 second two tone signal and exit.\n"
 	"\n"
 	" CAT and RTS PTT can share the same port.\n"
 	" See the ardop documentation for more information on cat and ptt options\n"
@@ -207,7 +210,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzw", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzwn", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -336,6 +339,10 @@ void processargs(int argc, char * argv[])
 
 		case 'w':
 			WriteRxWav = TRUE;
+			break;
+
+		case 'n':
+			TwoToneAndExit = TRUE;
 			break;
 
 		case '?':

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -77,6 +77,7 @@ extern char PlaybackDevice[80];
 int extraDelay = 0;				// Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
+BOOL WriteRxWav = FALSE;
 
 int PTTMode = PTTRTS;				// PTT Control Flags.
 
@@ -155,6 +156,7 @@ static struct option long_options[] =
 	{"extradelay",  required_argument, 0 , 'e'},
 	{"leaderlength",  required_argument, 0 , 'x'},
 	{"trailerlength",  required_argument, 0 , 't'},
+	{"writewav",  no_argument, 0, 'w'},
 	{"help",  no_argument, 0 , 'h'},
 	{ NULL , no_argument , NULL , no_argument }
 };
@@ -188,6 +190,7 @@ char HelpScreen[] =
 	"-e val or --extradelay val        Extend no response timeot for use on paths with long delay\n"
 	"--leaderlength val                Sets Leader Length (mS)\n"
 	"--trailerlength val               Sets Trailer Length (mS)\n"
+	"-w or --writewav                  Write WAV files of received audio for debugging.\n"
 	"\n"
 	" CAT and RTS PTT can share the same port.\n"
 	" See the ardop documentation for more information on cat and ptt options\n"
@@ -204,7 +207,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytz", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzw", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -329,6 +332,10 @@ void processargs(int argc, char * argv[])
 
 		case 't':
 			TrailerLength = atoi(optarg);
+			break;
+
+		case 'w':
+			WriteRxWav = TRUE;
 			break;
 
 		case '?':

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -136,7 +136,7 @@ int LastNow;
 
 extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
-
+void Send5SecTwoTone();
 
 extern struct sockaddr HamlibAddr;		// Dest for above
 extern int useHamLib;
@@ -145,6 +145,7 @@ extern int useHamLib;
 #define TARGET_RESOLUTION 1         // 1-millisecond target resolution
 
 extern BOOL WriteRxWav;
+extern BOOL TwoToneAndExit;
 struct WavFile *rxwf = NULL;
 #define RXWFTAILMS 10000;  // 10 seconds
 unsigned int rxwf_EndNow = 0;
@@ -413,6 +414,13 @@ void main(int argc, char * argv[])
 	if(!SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS))
 		printf("Failed to set High Priority (%d)\n"), GetLastError();
 
+	if (TwoToneAndExit)
+	{
+		InitSound(TRUE);
+		WriteDebugLog(LOGINFO, "Sending a 5 second 2-tone signal. Then exiting ardop.");
+		Send5SecTwoTone();
+		return;
+	}
 	ardopmain();
 }
 

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -111,6 +111,7 @@ typedef int BOOL;
 typedef unsigned char UCHAR;
 
 #define VOID void
+#define HANDLE int
 
 #define FALSE 0
 #define TRUE 1

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -44,6 +44,7 @@ unsigned int getTicks();
 #define LOGNOTICE 5
 #define LOGINFO 6
 #define LOGDEBUG 7
+#define LOGDEBUGPLUS 8
 
 #include <time.h>
 

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -112,7 +112,11 @@ typedef int BOOL;
 typedef unsigned char UCHAR;
 
 #define VOID void
+#ifdef WIN32
+typedef void *HANDLE;
+#else
 #define HANDLE int
+#endif
 
 #define FALSE 0
 #define TRUE 1

--- a/ARDOPCommonCode/wav.c
+++ b/ARDOPCommonCode/wav.c
@@ -1,0 +1,79 @@
+// Write data to single channel 16-bit signed integer WAV file with a sample rate of 12000 Hz
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "ardopcommon.h"
+#include "wav.h"
+
+// PCM WAV file header
+char WavHeader[] = {
+	0x52, 0x49, 0x46, 0x46, // "RIFF"
+	0x00, 0x00, 0x00, 0x00, // DUMMY file size - 8 in bytes = 2 * NumSamples + 36
+	0x57, 0x41, 0x56, 0x45, // "WAVE"
+	0x66, 0x6d, 0x74, 0x20, // "fmt "
+	0x10, 0x00, 0x00, 0x00, // Subchunk size = 16 for PCM
+	0x01, 0x00,             // WAVE type format
+	0x01, 0x00,             // single channel
+	0xE0, 0x2E, 0x00, 0x00, // sample rate = 12000 (Hz)
+	0xC0, 0x5D, 0x00, 0x00, // bytes/sec = 24000
+	0x02, 0x00,             // block alignment = (num channels * bitsPerChannel / 8) = 2
+	0x10, 0x00,             // bits per sample = 16
+	0x64, 0x61, 0x74, 0x61, // "data"
+	0x00, 0x00, 0x00, 0x00, // DUMMY data size in bytes = 2 * NumSamples for 16-bit samples
+};
+
+// Open a WAV for for writing.  Return NULL on failure.
+struct WavFile* OpenWavW(const char *pathname)
+{
+	WriteDebugLog(LOGDEBUG, "Opening WAV file for writing: %s", pathname);
+	struct WavFile *wf = (struct WavFile *) malloc(sizeof(struct WavFile));
+	if (wf == NULL)
+	{
+		WriteDebugLog(LOGDEBUG, "Unable to allocate WavFile struct.");
+		return NULL;
+	}
+		
+	wf->f = fopen(pathname, "wb");
+	if (wf->f == NULL)
+	{
+		WriteDebugLog(LOGDEBUG, "Unable to open WAV file.");
+		return NULL;
+	}
+		
+	wf->NumSamples = 0;
+	
+	// Write the header for the WAV file.  Use dummy values of 0 for size of file and size of chunk.
+	fwrite(WavHeader, 1, sizeof(WavHeader), wf->f);
+	return wf;
+}
+
+// Close a WAV file after updating the file header
+// If ardop is stopped while wf is open, then these required updates will not
+// be done, and the WAV file will not be valid.  However, using only the file
+// size, they can be fixed later.
+int CloseWav(struct WavFile *wf)
+{
+	int value;
+	int retval;
+	
+	WriteDebugLog(LOGDEBUG, "Finalizing and closing WAV file.");
+	// file length should be 44 + 2*wf->NumSamples
+	fseek(wf->f, 4, SEEK_SET);
+	value = 2 * wf->NumSamples + 36; 
+	fwrite(&value, 1, 4, wf->f);
+	fseek(wf->f, 40, SEEK_SET);
+	value = 2 * wf->NumSamples;
+	fwrite(&value, 1, 4, wf->f);
+	retval = fclose(wf->f);
+	free(wf);
+	return retval;
+}
+
+// Write data to an open WAV file
+int WriteWav(short *ptr, int num, struct WavFile *wf)
+{
+	// num is the number of 16-bit signed integers from ptr to be written
+	fwrite(ptr, 2, num, wf->f);
+	wf->NumSamples += num;
+	return (num * 2);
+}

--- a/ARDOPCommonCode/wav.h
+++ b/ARDOPCommonCode/wav.h
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+struct WavFile 
+{
+	FILE *f;
+	int NumSamples;
+};
+
+// Open a WAV for for writing.  Return NULL on failure.
+struct WavFile* OpenWavW(const char *pathname);
+
+// Close a WAV file after updating the file header
+int CloseWav(struct WavFile *wf);
+
+// Write data to WAV file
+int WriteWav(short *ptr, int num, struct WavFile *wf);


### PR DESCRIPTION
The behavior of ardopc, and what heard frames it will attempt to decode, depends upon its ProtocolMode.  Previously the available modes were ARQ and FEC.  This commit creates an additional RXO mode.  This receive-only ProtocolMode attempts to decode all frames heard regardless of frame Type or Session ID.  This is intended primarily as a tool to facilitate development and debugging of routines for demodulating and decoding.  It may also be of interest to anyone interested in monitoring Ardop traffic.

While SessionID is not used by RXO mode to decide which frames to decode, its value is extracted and logged for all frames.  This can be useful to see which frames are part of a session between the same stations/callsigns.  Thus, if the corresponding Connect Request frame was previously decoded, then the Session ID can be used to determine the callsigns for the sending and receiving stations for later received frames.

Like ARQ and FEC modes, RXO mode may be set by a host using the PROTOCOLMODE host command.  Current host applications are not configured to use this mode or issue this command.  Thus, results are logged to console and to the debug log file.  They are also sent to connected hosts as STATUS messages.  Additional work may be required to further support host applications.  

The -r or --receiveonly command line arguments may also be used to start ardopc in RXO mode.  This allows it to write the content of heard frames to the console and the debug log file without using any host application.  Note that most current host applications will override this setting and switch to ARQ or FEC mode upon connecting to ardop.